### PR TITLE
Fix coretype detection for Bay Trail Atom

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -1777,6 +1777,8 @@ int get_coretype(void){
 	break;
       case 3:
 	switch (model) {
+	case 7:
+	  return CORE_ATOM;		
 	case 10:
 	case 14:
 	  if(support_avx())


### PR DESCRIPTION
My earlier PR #982 appears to have been incomplete in this regard - fixes #1285