### PR TITLE
Move ARMv8 gcc build from Travis to Azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -202,7 +202,6 @@ matrix:
 
   allow_failures:
     - env: IMAGE_ARCH=arm32 TARGET_ARCH=ARMV6 COMPILER=clang
-    - env: IMAGE_ARCH=arm64 TARGET_ARCH=ARMV8 COMPILER=gcc
     - env: IMAGE_ARCH=arm64 TARGET_ARCH=ARMV8 COMPILER=clang
 
 # whitelist

--- a/.travis.yml
+++ b/.travis.yml
@@ -194,9 +194,6 @@ matrix:
             cmake --build ." > Dockerfile
         docker build .
     - <<: *emulated-arm
-      env: IMAGE_ARCH=arm64 TARGET_ARCH=ARMV8 COMPILER=gcc
-      name: "Emulated Build for ARMV8 with gcc"
-    - <<: *emulated-arm
       env: IMAGE_ARCH=arm64 TARGET_ARCH=ARMV8 COMPILER=clang
       name: "Emulated Build for ARMV8 with clang"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,26 @@ jobs:
             cmake --build ." > Dockerfile
       docker build .
     displayName: Run ARMV6 docker build
+- job: ARMv8_gcc
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - script: |
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      echo "FROM openblas/alpine:arm64
+        COPY . /tmp/openblas
+        RUN mkdir /tmp/openblas/build                             &&  \
+            cd /tmp/openblas/build                                &&  \
+            CC=gcc cmake -D DYNAMIC_ARCH=OFF                          \
+                                 -D TARGET=ARMV8                      \
+                                 -D NOFORTRAN=ON                      \
+                                 -D BUILD_SHARED_LIBS=ON              \
+                                 -D BUILD_WITHOUT_LAPACK=ON           \
+                                 -D BUILD_WITHOUT_CBLAS=ON            \
+                                 -D CMAKE_BUILD_TYPE=Release ../  &&  \
+            cmake --build ." > Dockerfile
+      docker build .
+    displayName: Run ARMV8 docker build   
 # manylinux1 is useful to test because the
 # standard Docker container uses an old version
 # of gcc / glibc


### PR DESCRIPTION
clang build would still time out even with the 60 minutes available on Azure, but the gcc job makes it 